### PR TITLE
Handle milk-free recipes in SupplyCalculator

### DIFF
--- a/Coffee Machine Simulator with Java/task/src/machine/supplycalculator/SupplyCalculator.java
+++ b/Coffee Machine Simulator with Java/task/src/machine/supplycalculator/SupplyCalculator.java
@@ -66,7 +66,12 @@ public class SupplyCalculator {
      */
     public int calculateSuppliesBeforeSell(Coffee coffee) {
         int cupsByWater = waterSupply / coffee.getWaterNeeded();
-        int cupsByMilk = coffee.getMilkNeeded() != 0? milkSupply / coffee.getMilkNeeded() : 1;
+        // if no milk is required for the recipe we shouldn't limit the amount of
+        // cups that can be made by milk supply, therefore use a sentinel value
+        // to effectively ignore milk in the minimum calculation
+        int cupsByMilk = coffee.getMilkNeeded() != 0
+                ? milkSupply / coffee.getMilkNeeded()
+                : Integer.MAX_VALUE;
         int cupsByCoffee = gramsCoffeeSupply / coffee.getCoffeeBeansNeeded();
         int disposableCupsNeeded = disposableCupsSupply / coffee.getDisposableCupsNeeded();
 


### PR DESCRIPTION
## Summary
- avoid limiting batches to 1 cup when a recipe doesn't use milk
- use `Integer.MAX_VALUE` sentinel in `calculateSuppliesBeforeSell`

## Testing
- `./gradlew test` *(fails: could not resolve dependencies)*
- manual check with `jshell` to verify espresso cups count

------
https://chatgpt.com/codex/tasks/task_e_6840ebc5fc1c8322b8fed822ee5592ba